### PR TITLE
Update cl_dropping.lua

### DIFF
--- a/fsn_inventory_dropping/cl_dropping.lua
+++ b/fsn_inventory_dropping/cl_dropping.lua
@@ -23,7 +23,9 @@ Citizen.CreateThread(function()
 							if exports['fsn_inventory']:fsn_CanCarry(d.item.index, d.item.amt) then
 								TriggerServerEvent('fsn_inventory:drops:collect', i)
 								PickupAnimation()
-							end
+							else
+								TriggerEvent('fsn_notify:displayNotification', 'You can not carry this item. (Max Weight Limit: 40)', 'centerLeft', 3000, 'error')
+							end	
 						end
 					end
 				end

--- a/fsn_inventory_dropping/cl_dropping.lua
+++ b/fsn_inventory_dropping/cl_dropping.lua
@@ -20,8 +20,10 @@ Citizen.CreateThread(function()
 					Util.DrawText3D(d.loc.x,d.loc.y,d.loc.z, '[ALT+E] Pickup~y~\n'..d.item.name, {255,255,255,200}, 0.25)
 					if IsControlPressed(0, 19) then
 						if IsControlJustPressed(0,38) then
-							TriggerServerEvent('fsn_inventory:drops:collect', i)
-							PickupAnimation()
+							if exports['fsn_inventory']:fsn_CanCarry(d.item.index, d.item.amt) then
+								TriggerServerEvent('fsn_inventory:drops:collect', i)
+								PickupAnimation()
+							end
 						end
 					end
 				end


### PR DESCRIPTION
Checks if the player can carry the item first, to avoid the item just deleting if the player cannot carry it.